### PR TITLE
Changed the script to use a regex pattern.

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,8 @@
+The regex pattern matches any string which:
+
+- Is preceeded by <a href="
+- begins with /wallpaper/
+- ends in jpg
+- preceeds ">
+
+I think this is enough to filter out only the wanted links. Note that the matched string will include the random part of the URL so that the user never has to specify it manually. Each filename also contains the resolution. This could be added to the pattern in case it stops working.

--- a/interfacelift.py
+++ b/interfacelift.py
@@ -1,29 +1,25 @@
 #!/usr/bin/env python
 import os
 import urllib2
+import re
 
 url       = 'http://interfacelift.com/wallpaper/downloads/date/hdtv/1080p/'
 directory = '/datapool/public/wallpaper/1080p'
 start     = '<a href="/wallpaper/i8r4q'  #check interfacelift.com to see what the randomly generated part is at the end
 end       = '">'
 useragent = 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 (.NET CLR 3.5.30729)'
+pattern   = '(?<=<a href=")/wallpaper/.*jpg(?=">)'
 
 count     = 1
 while count < 999999:
         data       = urllib2.urlopen(url + "index" + str(count) + ".html").read()
-        currentpos = 0
-        urlcount   = 0
-        while True:
-                index      = data.find(start, currentpos)
-                if index == -1:
-                        break
-                endofindex = data.find(end, index)
-                currentpos = index + 1
-                urlcount  += 1
-                if os.path.exists(directory + data[index+len(start):endofindex]):
+        pictures   = re.findall(pattern, data)
+        urlcount   = len(pictures)
+        for picture in pictures:
+                if os.path.exists(directory + picture):
                         print 'Directory up to date. Found existing file.'
                         quit()
-                os.system('wget -P ' + directory + ' -nc -U "' + useragent + '" ' + 'http://interfacelift.com' + data[index+9:endofindex])
+                os.system('wget -P ' + directory + ' -nc -U "' + useragent + '" ' + 'http://interfacelift.com' + picture)
         if urlcount == 0:
                 quit()
         count += 1

--- a/interfacelift.py
+++ b/interfacelift.py
@@ -5,10 +5,8 @@ import re
 
 url       = 'http://interfacelift.com/wallpaper/downloads/date/hdtv/1080p/'
 directory = '/datapool/public/wallpaper/1080p'
-start     = '<a href="/wallpaper/i8r4q'  #check interfacelift.com to see what the randomly generated part is at the end
-end       = '">'
 useragent = 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 (.NET CLR 3.5.30729)'
-pattern   = '(?<=<a href=")/wallpaper/.*jpg(?=">)'
+pattern   = '(?<=<a href=")/wallpaper/.*jpg(?=">)' # The regex pattern used. Check the README
 
 count     = 1
 while count < 999999:


### PR DESCRIPTION
Instead of traversing the data string in a loop, the whole string is matched against a pattern using look-behind and look-ahead. The result is a list of relative URLs for the pictures. The advantage is that the user doesn't have to manually find the random part of the URL.
